### PR TITLE
Wire user compliance to live API

### DIFF
--- a/PROJECT_SUMMARY.md
+++ b/PROJECT_SUMMARY.md
@@ -1,0 +1,197 @@
+# Sodzo WebClient — Project Summary
+
+## Overview
+
+A React-based web dashboard for **The Sword of the Spirit Ministries**, providing church/ministry management tools including form modules, network hierarchy, donations, e-commerce, calendar, team management, and compliance reporting.
+
+- **Live URL**: `https://stg.saby.ai`
+- **API Backend**: `https://api.saby.ai/v1`
+- **GitHub (upstream)**: `fadebowaley/sodzo-webclient`
+- **GitHub (fork)**: `4MHARK/sodzo-webclient`
+
+---
+
+## Tech Stack
+
+| Layer | Technology |
+|-------|-----------|
+| Framework | React 18 + TypeScript |
+| Build tool | Vite 5 |
+| Styling | Tailwind CSS 3 (dark mode via `class` strategy) |
+| Routing | React Router v7 |
+| Data fetching | @tanstack/react-query v5 |
+| HTTP client | Axios (with interceptors for auth, rate limiting, logging) |
+| Animations | Framer Motion |
+| Icons | Lucide React |
+| Charts | Recharts |
+| Local DB | Dexie.js (IndexedDB wrapper) |
+| Auth | JWT access + refresh tokens, HttpOnly cookies |
+| Notifications | react-hot-toast |
+| Deployment | Docker + GitHub Actions CI/CD |
+
+---
+
+## Architecture
+
+### Auth Flow
+
+```
+AuthContext (state machine)
+  ANONYMOUS → AUTHENTICATED → REFRESHING → SESSION_EXPIRED
+       ↑                                       │
+       └───────────── LOGGING_OUT ←────────────┘
+
+Tokens: access token (in-memory only), refresh token (localStorage + memory)
+API interceptors: auto-attach Bearer token, auto-refresh on 401, rate-limit backoff
+```
+
+### Route Structure
+
+```
+/                     Landing page (public)
+/auth                 Auth page (public)
+/about, /policy       Placeholder pages (public)
+
+Protected routes (under Layout with sidebar/header):
+  /dashboard          Metrics dashboard with charts
+  /projects           Form modules dashboard
+  /projects/submissions   Module submissions
+  /module-report/:id      Tenant-aware report table
+  /network            Node hierarchy management (tree view, CRUD)
+  /calendar           Calendar events
+  /emails             Email center
+  /storage            Cloud storage
+  /reports            Reports (leaderboard + compliance module reports)
+  /store              E-commerce store
+  /settings           User settings
+  /team               Team member management
+  /admin              Admin settings (owner-only)
+  /givings            Donations (payment link, QR, bank transfer, USSD, reports)
+  /user               User Compliance (NEW — see below)
+```
+
+### Key Files
+
+| File | Purpose |
+|------|---------|
+| `src/App.tsx` | All route definitions |
+| `src/contexts/AuthContext.tsx` | Auth state machine, login/logout, token management (~1200 lines) |
+| `src/utils/api.ts` | Axios instance with interceptors, refresh logic, rate limiting |
+| `src/utils/dbService.ts` | IndexedDB schema (Dexie.js) — 8 tables |
+| `src/components/ProtectedRoute.tsx` | Route guard, checks auth state |
+| `src/components/Layout/Layout.tsx` | App shell (sidebar + header + Outlet) |
+| `src/components/Layout/Sidebar.tsx` | Navigation sidebar |
+| `src/components/Layout/MobileLayout.tsx` | Mobile-optimized layout |
+
+---
+
+## What We Built: User Compliance Page
+
+### Files Changed
+
+| File | Change |
+|------|--------|
+| `src/pages/User.tsx` | **NEW** — User compliance report page (401 lines) |
+| `src/App.tsx` | Added route `/user` with ProtectedRoute wrapper |
+| `src/components/Layout/Sidebar.tsx` | Added `Users` icon import, "User" nav link |
+
+### Page Features
+
+- **Summary cards**: Compliant / Non-Compliant / Pending counts
+- **Search bar**: Filter by name, email, or role
+- **Sortable table**: Click column headers to sort (Name, Email, Roles, Status, Last Updated)
+- **Status badges**: Green (Compliant), Red (Non-Compliant), Yellow (Pending)
+- **Mock data mode**: `USE_MOCK = true` at top of file — shows 8 demo users
+- **Real data mode**: Set `USE_MOCK = false` to fetch from `http://localhost:3000/reports/baseline-intelligence/compliance`
+- **All states handled**: Loading spinner, error with retry button, empty state
+
+### How to Switch to Real Data
+
+In `src/pages/User.tsx`, change line 8:
+```tsx
+const USE_MOCK = false;  // was true
+```
+
+The page will then call `http://localhost:3000/reports/baseline-intelligence/compliance` via `fetch()`.
+
+---
+
+## Git Workflow
+
+### Branch Setup
+
+```
+LOCAL                              FORK (4MHARK)              UPSTREAM (fadebowaley)
+─────                              ─────────────              ──────────────────────
+mark        (working branch)  →    origin/mark
+proddy      (mirror)          →    origin/proddy      ←──    upstream/proddy
+```
+
+### Daily Workflow
+
+```bash
+# 1. Start of day — sync with upstream
+git checkout proddy
+git pull upstream proddy
+
+git checkout mark
+git merge proddy
+git push origin mark
+
+# 2. Create feature branch
+git checkout -b feat/my-feature
+
+# 3. Work, commit, push
+git add <files>
+git commit -m "feat: description"
+git push -u origin feat/my-feature
+
+# 4. Open PR on GitHub
+# From: 4MHARK/feat/my-feature → To: fadebowaley/proddy
+```
+
+---
+
+## Getting Started (New Developer)
+
+```bash
+# Clone the fork
+git clone git@github.com:4MHARK/sodzo-webclient.git
+cd sodzo-webclient
+
+# Add upstream
+git remote add upstream https://github.com/fadebowaley/sodzo-webclient.git
+git fetch upstream
+
+# Setup branches
+git checkout -b proddy upstream/proddy
+git checkout -b mark origin/mark
+
+# Install and run
+npm install
+npm run dev
+# Opens at http://localhost:5173
+```
+
+### Prerequisites
+- Node.js >= 18
+- npm >= 9
+- A browser with ad blocker disabled for localhost (lucide-react files get blocked)
+
+### Environment
+- `.env.local` — set `VITE_API_BASE` if using a local backend
+- No `.env` file needed — defaults to `https://api.saby.ai/v1`
+
+---
+
+## Current Branches
+
+| Branch | Commit | Notes |
+|--------|--------|-------|
+| `mark` | `ecb628a` | Personal working branch, synced with upstream |
+| `proddy` | `ecb628a` | Mirrors upstream/proddy |
+| `feat/user-compliance` | `cdbb03d` | Merged PR #22 |
+
+---
+
+*Last updated: 2026-07-04*

--- a/src/pages/User.tsx
+++ b/src/pages/User.tsx
@@ -2,115 +2,27 @@ import { useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { motion } from "framer-motion";
 import { Users, Shield, Search, ChevronDown, ChevronUp } from "lucide-react";
-
-// ─── SWITCH THIS WHEN BACKEND IS READY ───────────────────────────────────────
-// true  = show mock data (for demo / showing your boss)
-// false = fetch real data from localhost:3000
-const USE_MOCK = true;
-
-// The URL your boss gave you — a separate server from the main Saby API.
-const COMPLIANCE_URL =
-  "http://localhost:3000/reports/baseline-intelligence/compliance";
+import { useAuth } from "../contexts/AuthContext";
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
-interface ComplianceUser {
+/** Flattened row used for rendering — mapped from the API response. */
+interface ComplianceUserRow {
   id: string;
-  firstname: string;
-  lastname: string;
+  fullName: string;
   email: string;
-  roles: string[];
-  status: "Compliant" | "Non-Compliant" | "Pending";
+  status: "Compliant" | "Non-Compliant";
   lastUpdated: string;
 }
 
-// ─── Mock Data (remove this section when backend is live) ────────────────────
-
-const MOCK_USERS: ComplianceUser[] = [
-  {
-    id: "1",
-    firstname: "John",
-    lastname: "Okafor",
-    email: "john.okafor@swordofspirit.org",
-    roles: ["Pastor", "Admin"],
-    status: "Compliant",
-    lastUpdated: "2026-06-28T10:30:00Z",
-  },
-  {
-    id: "2",
-    firstname: "Grace",
-    lastname: "Adebayo",
-    email: "grace.adebayo@swordofspirit.org",
-    roles: ["Deacon", "Treasurer"],
-    status: "Compliant",
-    lastUpdated: "2026-06-25T14:15:00Z",
-  },
-  {
-    id: "3",
-    firstname: "David",
-    lastname: "Emmanuel",
-    email: "david.emmanuel@swordofspirit.org",
-    roles: ["Usher", "Member"],
-    status: "Non-Compliant",
-    lastUpdated: "2026-07-01T09:00:00Z",
-  },
-  {
-    id: "4",
-    firstname: "Mary",
-    lastname: "Chukwu",
-    email: "mary.chukwu@swordofspirit.org",
-    roles: ["Choir", "Member"],
-    status: "Pending",
-    lastUpdated: "2026-07-02T16:45:00Z",
-  },
-  {
-    id: "5",
-    firstname: "Samuel",
-    lastname: "Ibrahim",
-    email: "samuel.ibrahim@swordofspirit.org",
-    roles: ["Elder", "Admin", "Finance"],
-    status: "Compliant",
-    lastUpdated: "2026-06-30T11:20:00Z",
-  },
-  {
-    id: "6",
-    firstname: "Esther",
-    lastname: "Nwachukwu",
-    email: "esther.nwachukwu@swordofspirit.org",
-    roles: ["Sunday School", "Member"],
-    status: "Non-Compliant",
-    lastUpdated: "2026-06-20T08:00:00Z",
-  },
-  {
-    id: "7",
-    firstname: "Peter",
-    lastname: "Oluwaseun",
-    email: "peter.oluwaseun@swordofspirit.org",
-    roles: ["Security", "Member"],
-    status: "Pending",
-    lastUpdated: "2026-07-03T07:30:00Z",
-  },
-  {
-    id: "8",
-    firstname: "Deborah",
-    lastname: "Akintola",
-    email: "deborah.akintola@swordofspirit.org",
-    roles: ["Counselor", "Deacon"],
-    status: "Compliant",
-    lastUpdated: "2026-06-29T13:00:00Z",
-  },
-];
-
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
-function getStatusBadge(status: ComplianceUser["status"]) {
+function getStatusBadge(status: ComplianceUserRow["status"]) {
   switch (status) {
     case "Compliant":
       return "bg-green-100 dark:bg-green-900/30 text-green-800 dark:text-green-300";
     case "Non-Compliant":
       return "bg-red-100 dark:bg-red-900/30 text-red-800 dark:text-red-300";
-    case "Pending":
-      return "bg-yellow-100 dark:bg-yellow-900/30 text-yellow-800 dark:text-yellow-300";
     default:
       return "bg-gray-100 dark:bg-gray-700 text-gray-800 dark:text-gray-300";
   }
@@ -119,14 +31,12 @@ function getStatusBadge(status: ComplianceUser["status"]) {
 // ─── Page Component ──────────────────────────────────────────────────────────
 
 export default function User() {
+  const { api } = useAuth();
   const [search, setSearch] = useState("");
-  const [sortKey, setSortKey] = useState<keyof ComplianceUser | "">("");
+  const [sortKey, setSortKey] = useState<keyof ComplianceUserRow | "">("");
   const [sortDir, setSortDir] = useState<"asc" | "desc">("asc");
 
   // ── Data Fetching ────────────────────────────────────────────────────────
-  // When USE_MOCK is true: returns fake data instantly (for demo).
-  // When USE_MOCK is false: hits localhost:3000 for real data.
-  // Just flip the USE_MOCK flag at the top when your backend is ready.
 
   const {
     data: users = [],
@@ -135,22 +45,20 @@ export default function User() {
     refetch,
   } = useQuery({
     queryKey: ["user-compliance"],
-    queryFn: async (): Promise<ComplianceUser[]> => {
-      if (USE_MOCK) {
-        // Simulate network delay so the loading spinner is visible briefly
-        await new Promise((r) => setTimeout(r, 500));
-        return MOCK_USERS;
-      }
+    queryFn: async (): Promise<ComplianceUserRow[]> => {
+      const response = await api.get("/compliance/table", {
+        params: { limit: 100, sortBy: "overallCompliance", sortOrder: "desc" },
+      });
 
-      // Real API call — runs when USE_MOCK is false
-      const response = await fetch(COMPLIANCE_URL);
-      if (!response.ok) {
-        throw new Error(
-          `Server returned ${response.status}: ${response.statusText}`
-        );
-      }
-      const json = await response.json();
-      return json.results || json.data || json;
+      const records = response.data?.data || [];
+
+      return records.map((r: any) => ({
+        id: r.id,
+        fullName: r.user?.fullName || "—",
+        email: r.user?.email || "—",
+        status: r.isCompliant ? "Compliant" : "Non-Compliant",
+        lastUpdated: r.updatedAt || r.createdAt,
+      }));
     },
     retry: 1,
   });
@@ -161,10 +69,8 @@ export default function User() {
     if (!search.trim()) return true;
     const q = search.toLowerCase();
     return (
-      u.firstname?.toLowerCase().includes(q) ||
-      u.lastname?.toLowerCase().includes(q) ||
-      u.email?.toLowerCase().includes(q) ||
-      u.roles?.join(" ").toLowerCase().includes(q)
+      u.fullName?.toLowerCase().includes(q) ||
+      u.email?.toLowerCase().includes(q)
     );
   });
 
@@ -174,14 +80,14 @@ export default function User() {
     const bv = b[sortKey];
     if (av == null) return 1;
     if (bv == null) return -1;
-    const aStr = Array.isArray(av) ? av.join(", ") : String(av);
-    const bStr = Array.isArray(bv) ? bv.join(", ") : String(bv);
+    const aStr = String(av);
+    const bStr = String(bv);
     return sortDir === "asc"
       ? aStr.localeCompare(bStr)
       : bStr.localeCompare(aStr);
   });
 
-  const toggleSort = (key: keyof ComplianceUser) => {
+  const toggleSort = (key: keyof ComplianceUserRow) => {
     if (sortKey === key) {
       setSortDir((d) => (d === "asc" ? "desc" : "asc"));
     } else {
@@ -193,7 +99,7 @@ export default function User() {
   const counts = {
     compliant: users.filter((u) => u.status === "Compliant").length,
     nonCompliant: users.filter((u) => u.status === "Non-Compliant").length,
-    pending: users.filter((u) => u.status === "Pending").length,
+    pending: 0, // API has no "Pending" concept — kept for layout compatibility
   };
 
   // ── Render ───────────────────────────────────────────────────────────────
@@ -245,7 +151,7 @@ export default function User() {
           <Search className="absolute left-4 top-1/2 -translate-y-1/2 w-5 h-5 text-gray-400" />
           <input
             type="text"
-            placeholder="Search by name, email, or role..."
+            placeholder="Search by name or email..."
             value={search}
             onChange={(e) => setSearch(e.target.value)}
             className="w-full pl-12 pr-4 py-3 border border-gray-300 dark:border-gray-600 rounded-xl bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:ring-2 focus:ring-blue-500 focus:border-transparent shadow-sm"
@@ -280,7 +186,7 @@ export default function User() {
               Failed to load compliance data
             </p>
             <p className="text-sm text-gray-500 dark:text-gray-400 mb-4">
-              {(error as any)?.message || "Is the backend running on port 3000?"}
+              {(error as any)?.message || "Could not reach the compliance endpoint."}
             </p>
             <button
               onClick={() => refetch()}
@@ -305,12 +211,11 @@ export default function User() {
         {!isLoading && !error && users.length > 0 && (
           <>
             {/* Column Headers */}
-            <div className="bg-gray-50 dark:bg-gray-900/50 border-b border-gray-200 dark:border-gray-700 px-4 py-3 hidden md:grid md:grid-cols-12 gap-4 text-xs font-semibold text-gray-600 dark:text-gray-400 uppercase tracking-wide">
+            <div className="bg-gray-50 dark:bg-gray-900/50 border-b border-gray-200 dark:border-gray-700 px-4 py-3 hidden md:grid md:grid-cols-10 gap-4 text-xs font-semibold text-gray-600 dark:text-gray-400 uppercase tracking-wide">
               {(
                 [
-                  { key: "firstname" as const, label: "Name", span: "md:col-span-3" },
+                  { key: "fullName" as const, label: "Name", span: "md:col-span-3" },
                   { key: "email" as const, label: "Email", span: "md:col-span-3" },
-                  { key: "roles" as const, label: "Roles", span: "md:col-span-2" },
                   { key: "status" as const, label: "Status", span: "md:col-span-2" },
                   { key: "lastUpdated" as const, label: "Last Updated", span: "md:col-span-2" },
                 ]
@@ -341,37 +246,17 @@ export default function User() {
                   transition={{ delay: i * 0.02 }}
                   className="px-4 py-3 hover:bg-gray-50 dark:hover:bg-gray-700/50 transition-colors"
                 >
-                  <div className="grid grid-cols-1 md:grid-cols-12 gap-4 items-center">
+                  <div className="grid grid-cols-1 md:grid-cols-10 gap-4 items-center">
                     {/* Name */}
                     <div className="md:col-span-3">
                       <span className="font-semibold text-gray-900 dark:text-white">
-                        {u.firstname} {u.lastname}
+                        {u.fullName}
                       </span>
                     </div>
 
                     {/* Email */}
                     <div className="md:col-span-3 text-sm text-gray-600 dark:text-gray-400 truncate">
                       {u.email}
-                    </div>
-
-                    {/* Roles */}
-                    <div className="md:col-span-2">
-                      <div className="flex flex-wrap gap-1">
-                        {u.roles?.length > 0 ? (
-                          u.roles.map((role) => (
-                            <span
-                              key={role}
-                              className="inline-flex px-2 py-0.5 rounded-full text-xs font-medium bg-blue-100 dark:bg-blue-900/30 text-blue-700 dark:text-blue-300"
-                            >
-                              {role}
-                            </span>
-                          ))
-                        ) : (
-                          <span className="text-gray-400 text-sm italic">
-                            No roles
-                          </span>
-                        )}
-                      </div>
                     </div>
 
                     {/* Status */}


### PR DESCRIPTION
Replaced hardcoded mock data on the user compliance page with the live `/v1/compliance/table/` endpoint

. Remove USE_MOCK flag, MOCK_USERS array and localhost fetch
. Fetch 75 real compliance records via authenticated SABY API
. Map API fields: user.fullName, user.email, isCompliant, updatedAt